### PR TITLE
Read only nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 .vagrant
+*.todo

--- a/spec/DhtNodeCommmander_spec.coffee
+++ b/spec/DhtNodeCommmander_spec.coffee
@@ -7,15 +7,14 @@ describe "DhtNodeCommander" , ->
 
 		beforeEach ->
 			@node = new DhtNode
-			@node.map = {
+			@node.torrentMap = {
 				"infohashHerp" : "herp"
 				"infohashLol" : "lol"
 				"infohashLmao" : "lmao"
 				"infohashMate" : "mate"
 				"infohashRate" : "rate"
 			}
-			spyOn(@node, "search").and.callThrough()
-			spyOn(@node, "getIndex").and.callThrough()
+			spyOn(@node, "getTorrentIndex").and.callThrough()
 
 			holdResult = (result) =>
 				@result = result
@@ -23,12 +22,7 @@ describe "DhtNodeCommander" , ->
 			@dhc = new DhtNodeCommander @node
 			@dhc.init holdResult
 
-		it "should search when commanded to" , ->
-			@dhc.parseCommand "search h"
-			expect(@node.search).toHaveBeenCalled()
-			expect(@result).toEqual { "infohashHerp" : "herp" }
-
-		it "should getIndex when commanded to" , ->
-			@dhc.parseCommand "getIndex"
-			expect(@node.getIndex).toHaveBeenCalled()
-			expect(@result).toBe @node.map
+		it "should getTorrentIndex when commanded to" , ->
+			@dhc.parseCommand "getTorrentIndex"
+			expect(@node.getTorrentIndex).toHaveBeenCalled()
+			expect(@result).toBe @node.torrentMap

--- a/spec/DhtNodeCommmander_spec.coffee
+++ b/spec/DhtNodeCommmander_spec.coffee
@@ -5,24 +5,26 @@ describe "DhtNodeCommander" , ->
 
 	describe "#parseCommand",  ->
 
-		beforeEach ->
-			@node = new DhtNode
-			@node.torrentMap = {
-				"infohashHerp" : "herp"
-				"infohashLol" : "lol"
-				"infohashLmao" : "lmao"
-				"infohashMate" : "mate"
-				"infohashRate" : "rate"
-			}
-			spyOn(@node, "getTorrentIndex").and.callThrough()
+		describe "getTorrentIndex" , ->
 
-			holdResult = (result) =>
-				@result = result
+			beforeEach ->
+				@node = new DhtNode
+				@node.torrentMap = {
+					"infohashHerp" : "herp"
+					"infohashLol" : "lol"
+					"infohashLmao" : "lmao"
+					"infohashMate" : "mate"
+					"infohashRate" : "rate"
+				}
+				spyOn(@node, "getTorrentIndex").and.callThrough()
 
-			@dhc = new DhtNodeCommander @node
-			@dhc.init holdResult
+				holdResult = (result) =>
+					@result = result
 
-		it "should getTorrentIndex when commanded to" , ->
-			@dhc.parseCommand "getTorrentIndex"
-			expect(@node.getTorrentIndex).toHaveBeenCalled()
-			expect(@result).toBe @node.torrentMap
+				@dhc = new DhtNodeCommander @node
+				@dhc.init holdResult
+
+			it "should getTorrentIndex when commanded to" , ->
+				@dhc.parseCommand "getTorrentIndex"
+				expect(@node.getTorrentIndex).toHaveBeenCalled()
+				expect(@result).toBe @node.torrentMap

--- a/spec/DhtNodeCommmander_spec.coffee
+++ b/spec/DhtNodeCommmander_spec.coffee
@@ -28,3 +28,24 @@ describe "DhtNodeCommander" , ->
 				@dhc.parseCommand "getTorrentIndex"
 				expect(@node.getTorrentIndex).toHaveBeenCalled()
 				expect(@result).toBe @node.torrentMap
+
+		describe "getNodeIndex", ->
+
+			beforeEach ->
+				@node = new DhtNode
+				@node.nodeMap = {
+					"localhost": 9999
+					"torrentz.eu": 9999
+					"thepiratebay.org": 9999
+					"isohunt.com": 9999
+				}
+				spyOn(@node, "getNodeIndex").and.callThrough()
+
+				holdResult = (result) =>
+					@result = result
+
+				@dhc = new DhtNodeCommander @node
+				@dhc.init holdResult
+
+			it "should respond to the call", ->
+				expect(@node.getNodeIndex).toBeDefined()

--- a/spec/DhtNodeCommmander_spec.coffee
+++ b/spec/DhtNodeCommmander_spec.coffee
@@ -49,3 +49,9 @@ describe "DhtNodeCommander" , ->
 
 			it "should respond to the call", ->
 				expect(@node.getNodeIndex).toBeDefined()
+
+			it "should getNodeIndex when commanded to", ->
+				@dhc.parseCommand "getNodeIndex"
+				expect(@node.getNodeIndex).toHaveBeenCalled()
+				expect(@result).toBe @node.nodeMap
+

--- a/spec/DhtNode_spec.coffee
+++ b/spec/DhtNode_spec.coffee
@@ -10,21 +10,13 @@ describe "DhtNode", ->
 
 	createNode= ->
 		node = new DhtNode()
-		node.map = {
+		node.torrentMap = {
 			"infohashHerp": "herp"
 			"infohashHerpaDerp": "herpderpa"
 			"infohashDerp": "derp"
 			"infohashLol": "lol"
 		}
 		return node
-
-	describe "#search", ->
-
-		beforeEach ->
-			@node = createNode()
-
-		it "should search for items", ->
-			expect(@node.search "l").toEqual { "infohashLol": "lol" }
 
 	describe "network" , ->
 
@@ -50,24 +42,10 @@ describe "DhtNode", ->
 				@node.end()
 
 			it "should respond to getIndex", (done) ->
-				expectedIndex = JSON.stringify @node.map
+				expectedIndex = JSON.stringify @node.torrentMap
 				@socket.on "data", (buffer)=>
 					data = buffer.toString()
 					expect(data).toEqual expectedIndex
 					done()
 
-				@socket.write "getIndex"
-
-			it "should respond to search", (done) ->
-				expected = JSON.stringify {
-						"infohashHerp": "herp"
-						"infohashHerpaDerp": "herpderpa"
-					}
-
-				@socket.on "data", (buffer)=>
-
-					received = buffer.toString()
-					expect(received).toEqual expected
-					done()
-
-				@socket.write "search h"
+				@socket.write "getTorrentIndex"

--- a/spec/DhtNode_spec.coffee
+++ b/spec/DhtNode_spec.coffee
@@ -16,6 +16,12 @@ describe "DhtNode", ->
 			"infohashDerp": "derp"
 			"infohashLol": "lol"
 		}
+		node.nodeMap = {
+			"localhost": 9999
+			"torrentz.eu": 9999
+			"thepiratebay.org": 9999
+			"isohunt.com": 9999
+		}
 		return node
 
 	describe "network" , ->
@@ -41,7 +47,7 @@ describe "DhtNode", ->
 				@socket.end()
 				@node.end()
 
-			it "should respond to getIndex", (done) ->
+			it "should respond to getTorrentIndex", (done) ->
 				expectedIndex = JSON.stringify @node.torrentMap
 				@socket.on "data", (buffer)=>
 					data = buffer.toString()
@@ -49,3 +55,12 @@ describe "DhtNode", ->
 					done()
 
 				@socket.write "getTorrentIndex"
+
+			it "should respond to getNodeIndex", (done) ->
+				expectedIndex = JSON.stringify @node.nodeMap
+				@socket.on "data", (buffer)=>
+					data = buffer.toString()
+					expect(data).toEqual expectedIndex
+					done()
+
+				@socket.write "getNodeIndex"

--- a/src/DhtNode.coffee
+++ b/src/DhtNode.coffee
@@ -15,6 +15,7 @@ A P2P node that can listen to a port on an interface and react to commands given
 class DhtNode
 	constructor: ()->
 		@torrentMap = {}
+		@nodeMap = {}
 		@server = null
 		@commander = null
 
@@ -75,9 +76,17 @@ class DhtNode
 		return res
 
 	###
-	@returns {Object} All KVPs this node has
+	@returns {Object} All torrent KVPs this node has
 	###
 	getTorrentIndex: =>
 		@torrentMap
+
+	###
+	@returns {Object} All node KVPs this node has
+	###
+	getNodeIndex: =>
+		@nodeMap
+
+
 
 module.exports = DhtNode

--- a/src/DhtNode.coffee
+++ b/src/DhtNode.coffee
@@ -14,7 +14,7 @@ A P2P node that can listen to a port on an interface and react to commands given
 ###
 class DhtNode
 	constructor: ()->
-		@map = {}
+		@torrentMap = {}
 		@server = null
 		@commander = null
 
@@ -69,15 +69,15 @@ class DhtNode
 	###
 	search: (query) =>
 		# pick keys that have values starting with <query>
-		res = _.pick @map,
-			Object.keys(@map).filter (key)=>
-				@map[key].startsWith query
+		res = _.pick @torrentMap,
+			Object.keys(@torrentMap).filter (key)=>
+				@torrentMap[key].startsWith query
 		return res
 
 	###
 	@returns {Object} All KVPs this node has
 	###
-	getIndex: =>
-		@map
+	getTorrentIndex: =>
+		@torrentMap
 
 module.exports = DhtNode

--- a/src/DhtNodeCommander.coffee
+++ b/src/DhtNodeCommander.coffee
@@ -18,6 +18,10 @@ class DhtNodeCommander
 		.command("getTorrentIndex")
 		.action _.compose(method, @dhtNode.getTorrentIndex)
 
+		@program
+		.command("getNodeIndex")
+		.action _.compose(method, @dhtNode.getNodeIndex)
+
 
 	parseCommand: (input) =>
 		# expects argv so we simulate it

--- a/src/DhtNodeCommander.coffee
+++ b/src/DhtNodeCommander.coffee
@@ -13,14 +13,10 @@ class DhtNodeCommander
 	###
 	init: (method = console.log)->
 
-		@program
-		.command("search <query>")
-		.action _.compose(method, @dhtNode.search)
-
 		#
 		@program
-		.command("getIndex")
-		.action _.compose(method, @dhtNode.getIndex)
+		.command("getTorrentIndex")
+		.action _.compose(method, @dhtNode.getTorrentIndex)
 
 
 	parseCommand: (input) =>


### PR DESCRIPTION
Make nodes read-only by other nodes. They will only accept the commands `getNodeIndex` and `getTorrentIndex`.